### PR TITLE
Allow to use positional argument instead of --dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ const bugspots = new Bugspots();
 const spots = await bugspots.scan();
 console.log(spots);
 ```
+
+## Debug
+
+```bash
+$ npx tsx src/debug.ts <flags>
+```

--- a/src/BugspotsOptions.ts
+++ b/src/BugspotsOptions.ts
@@ -29,8 +29,9 @@ function parseNumberIfExist(s: string | null | undefined): number | undefined {
 }
 
 export function parseBugspotsOptions(args: string[]): BugspotsOptions {
-  const { values } = parseArgs({
+  const { values, positionals } = parseArgs({
     args,
+    allowPositionals: true,
     options: {
       concurrency: { type: 'string' },
       depth: { type: 'string', short: 'd' },
@@ -42,7 +43,7 @@ export function parseBugspotsOptions(args: string[]): BugspotsOptions {
     },
   });
 
-  const baseDir = values.dir ?? '.';
+  const baseDir = values.dir ?? positionals[0] ?? '.';
   const depth = parseNumberIfExist(values.depth);
   const concurrency = parseNumberIfExist(values.concurrency);
   const regexString = values.regex ?? '\\b(fix(es|ed)?|close(s|d)?)\\b';

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -30,6 +30,7 @@ export class Git {
     const diffList: GitDiff[] = res
       .trim()
       .split(/\r?\n/)
+      .filter((line) => line.length > 0)
       .map((line) => {
         // Example:
         // [A|M|R|D] \t file \n

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,6 @@
+import { run } from './run';
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Before
```bash
$ simple-bugspots --dir /path/to/repo
```

## After
```bash
$ simple-bugspots /path/to/repo
$ simple-bugspots --dir /path/to/repo
```